### PR TITLE
Full data on click

### DIFF
--- a/Angular/src/app/features/aircraft-maintenance-companies/children/maintenance-teams/views/maintenance-teams-index/maintenance-teams-index.component.html
+++ b/Angular/src/app/features/aircraft-maintenance-companies/children/maintenance-teams/views/maintenance-teams-index/maintenance-teams-index.component.html
@@ -39,7 +39,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/aircraft-maintenance-companies/children/maintenance-teams/views/maintenance-teams-index/maintenance-teams-index.component.ts
+++ b/Angular/src/app/features/aircraft-maintenance-companies/children/maintenance-teams/views/maintenance-teams-index/maintenance-teams-index.component.ts
@@ -37,8 +37,8 @@ export class MaintenanceTeamsIndexComponent extends CrudItemsIndexComponent<Main
   }
 
     // Custo for teams
-    onClickRow(crudItemId: any) {
-      this.onManageMember(crudItemId)
+    onClickRow(crudItem: any) {
+      this.onManageMember(crudItem.id)
     }
   
     onManageMember(crudItemId: any) {

--- a/Angular/src/app/features/aircraft-maintenance-companies/views/aircraft-maintenance-companies-index/aircraft-maintenance-companies-index.component.html
+++ b/Angular/src/app/features/aircraft-maintenance-companies/views/aircraft-maintenance-companies-index/aircraft-maintenance-companies-index.component.html
@@ -45,7 +45,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/aircraft-maintenance-companies/views/aircraft-maintenance-companies-index/aircraft-maintenance-companies-index.component.ts
+++ b/Angular/src/app/features/aircraft-maintenance-companies/views/aircraft-maintenance-companies-index/aircraft-maintenance-companies-index.component.ts
@@ -37,8 +37,8 @@ export class AircraftMaintenanceCompaniesIndexComponent extends CrudItemsIndexCo
   }
 
     // Custo for teams
-    onClickRow(crudItemId: any) {
-      this.onManageMember(crudItemId)
+    onClickRow(crudItem: any) {
+      this.onManageMember(crudItem.id)
     }
   
     onManageMember(crudItemId: any) {

--- a/Angular/src/app/features/airports/views/airports-index/airports-index.component.html
+++ b/Angular/src/app/features/airports/views/airports-index/airports-index.component.html
@@ -28,7 +28,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/bia-features/notifications/views/notifications-index/notifications-index.component.ts
+++ b/Angular/src/app/features/bia-features/notifications/views/notifications-index/notifications-index.component.ts
@@ -135,8 +135,8 @@ export class NotificationsIndexComponent implements OnInit, OnDestroy {
     this.router.navigate(['./' + notificationId + '/edit'], { relativeTo: this.activatedRoute });
   }
 
-  onDetail(notificationId: number) {
-    this.router.navigate(['./' + notificationId + '/detail'], { relativeTo: this.activatedRoute });
+  onDetail(notification: any) {
+    this.router.navigate(['./' + notification.id + '/detail'], { relativeTo: this.activatedRoute });
 
     // this.store.select(getNotificationById(notificationId)).pipe(first()).subscribe(notif => {
     //   if (notif && !notif.read) {

--- a/Angular/src/app/features/bia-features/users/views/users-index/users-index.component.html
+++ b/Angular/src/app/features/bia-features/users/views/users-index/users-index.component.html
@@ -37,7 +37,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/planes-full-code/views/planes-index/planes-index.component.ts
+++ b/Angular/src/app/features/planes-full-code/views/planes-index/planes-index.component.ts
@@ -145,9 +145,9 @@ export class PlanesIndexComponent implements OnInit, OnDestroy {
     }
   }
 
-  onEdit(planeId: number) {
+  onEdit(plane: any) {
     if (!this.useCalcMode) {
-      this.router.navigate([planeId, 'edit'], { relativeTo: this.activatedRoute });
+      this.router.navigate([plane.id, 'edit'], { relativeTo: this.activatedRoute });
     }
   }
 

--- a/Angular/src/app/features/planes-specific/views/planes-index/planes-index.component.html
+++ b/Angular/src/app/features/planes-specific/views/planes-index/planes-index.component.html
@@ -28,7 +28,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/planes-types/views/planes-types-index/planes-types-index.component.html
+++ b/Angular/src/app/features/planes-types/views/planes-types-index/planes-types-index.component.html
@@ -28,7 +28,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/planes/views/planes-index/planes-index.component.html
+++ b/Angular/src/app/features/planes/views/planes-index/planes-index.component.html
@@ -28,7 +28,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/sites/views/sites-index/sites-index.component.html
+++ b/Angular/src/app/features/sites/views/sites-index/sites-index.component.html
@@ -49,7 +49,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/features/sites/views/sites-index/sites-index.component.ts
+++ b/Angular/src/app/features/sites/views/sites-index/sites-index.component.ts
@@ -43,8 +43,8 @@ export class SitesIndexComponent extends CrudItemsIndexComponent<Site> {
   }
   
   // Custo for teams
-  onClickRow(crudItemId: any) {
-    this.onManageMember(crudItemId)
+  onClickRow(crudItem: any) {
+    this.onManageMember(crudItem.id)
   }
 
   onManageMember(crudItemId: any) {

--- a/Angular/src/app/shared/bia-shared/components/table/bia-calc-table/bia-calc-table.component.html
+++ b/Angular/src/app/shared/bia-shared/components/table/bia-calc-table/bia-calc-table.component.html
@@ -86,7 +86,7 @@
                   [data]="getCellData(rowData, col)"
                   >
                     <ng-template pTemplate="specificOutput">
-                      <ng-container *ngTemplateOutlet="specificOutputTemplate;context: { field: col, data: getCellData(rowData, col) }" ></ng-container>
+                      <ng-container *ngTemplateOutlet="specificOutputTemplate;context: { parentData : rowData, field: col, data: getCellData(rowData, col) }" ></ng-container>
                     </ng-template>
                   </bia-table-output>
                 </ng-container>
@@ -103,7 +103,7 @@
                 [data]="getCellData(rowData, col)"
                 >
                   <ng-template pTemplate="specificOutput">
-                    <ng-container *ngTemplateOutlet="specificOutputTemplate;context: { field: col, data: getCellData(rowData, col) }" ></ng-container>
+                    <ng-container *ngTemplateOutlet="specificOutputTemplate;context: { parentData : rowData, field: col, data: getCellData(rowData, col) }" ></ng-container>
                   </ng-template>
                 </bia-table-output>
               </ng-template>

--- a/Angular/src/app/shared/bia-shared/components/table/bia-table/bia-table.component.html
+++ b/Angular/src/app/shared/bia-shared/components/table/bia-table/bia-table.component.html
@@ -49,7 +49,7 @@
       <td *ngIf="canSelectElement">
         <p-tableCheckbox [value]="rowData"></p-tableCheckbox>
       </td>
-      <td (click)="clickElement(rowData.id)" *ngFor="let col of columns">
+      <td (click)="clickElement(rowData)" *ngFor="let col of columns">
         <bia-table-output
         [field]="col"
         [data]="getCellData(rowData, col)"

--- a/Angular/src/app/shared/bia-shared/components/table/bia-table/bia-table.component.html
+++ b/Angular/src/app/shared/bia-shared/components/table/bia-table/bia-table.component.html
@@ -55,7 +55,7 @@
         [data]="getCellData(rowData, col)"
         >
           <ng-template pTemplate="specificOutput">
-            <ng-container *ngTemplateOutlet="specificOutputTemplate;context: { field: col, data: getCellData(rowData, col) }" ></ng-container>
+            <ng-container *ngTemplateOutlet="specificOutputTemplate;context: { parentData : rowData, field: col, data: getCellData(rowData, col) }" ></ng-container>
           </ng-template>
         </bia-table-output>
       </td>

--- a/Angular/src/app/shared/bia-shared/components/table/bia-table/bia-table.component.ts
+++ b/Angular/src/app/shared/bia-shared/components/table/bia-table/bia-table.component.ts
@@ -41,7 +41,7 @@ export class BiaTableComponent implements OnChanges, AfterContentInit {
   @Input() actionColumnLabel = 'bia.actions';
   @Input() showLoadingAfter = 100;
 
-  @Output() clickRow = new EventEmitter<number>();
+  @Output() clickRow = new EventEmitter<any>();
   @Output() filter = new EventEmitter<number>();
   @Output() loadLazy = new EventEmitter<LazyLoadEvent>();
   @Output() selectedElementsChanged = new EventEmitter<any[]>();
@@ -278,9 +278,9 @@ export class BiaTableComponent implements OnChanges, AfterContentInit {
     }
   }
 
-  clickElement(itemId: number) {
+  clickElement(rowData: any) {
     if (this.canClickRow) {
-      this.clickRow.emit(itemId);
+      this.clickRow.emit(rowData);
     }
   }
 

--- a/Angular/src/app/shared/bia-shared/feature-templates/crud-items/views/crud-items-index/crud-items-index.component.html
+++ b/Angular/src/app/shared/bia-shared/feature-templates/crud-items/views/crud-items-index/crud-items-index.component.html
@@ -28,7 +28,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"

--- a/Angular/src/app/shared/bia-shared/feature-templates/crud-items/views/crud-items-index/crud-items-index.component.ts
+++ b/Angular/src/app/shared/bia-shared/feature-templates/crud-items/views/crud-items-index/crud-items-index.component.ts
@@ -91,9 +91,9 @@ export class CrudItemsIndexComponent<CrudItem extends BaseDto> implements OnInit
     this.useViewConfig(true);
   }
 
-  useClacModeChange(e: boolean) {
+  useCalcModeChange(e: boolean) {
     this.crudConfiguration.useCalcMode = e;
-    this.useClacModeConfig(true);
+    this.useCalcModeConfig(true);
   }
 
   useSignalRChange(e: boolean) {
@@ -123,7 +123,7 @@ export class CrudItemsIndexComponent<CrudItem extends BaseDto> implements OnInit
   }
 
   isLoadAllOptionsSubsribe = false;
-  protected useClacModeConfig(manualChange: boolean) {
+  protected useCalcModeConfig(manualChange: boolean) {
     if (this.crudConfiguration.useCalcMode && ! this.isLoadAllOptionsSubsribe) {
       this.isLoadAllOptionsSubsribe = true;
       this.sub.add(
@@ -218,7 +218,7 @@ export class CrudItemsIndexComponent<CrudItem extends BaseDto> implements OnInit
 
   OnDisplay() {
     this.useViewConfig(false);
-    this.useClacModeConfig(false);
+    this.useCalcModeConfig(false);
     this.useSignalRConfig(false);
     this.usePopupConfig(false);
   }

--- a/Angular/src/app/shared/bia-shared/feature-templates/crud-items/views/crud-items-index/crud-items-index.component.ts
+++ b/Angular/src/app/shared/bia-shared/feature-templates/crud-items/views/crud-items-index/crud-items-index.component.ts
@@ -235,8 +235,8 @@ export class CrudItemsIndexComponent<CrudItem extends BaseDto> implements OnInit
     }
   }
 
-  onClickRow(crudItemId: any) {
-    this.onEdit(crudItemId)
+  onClickRow(crudItem: any) {
+    this.onEdit(crudItem.id)
   }
 
   onEdit(crudItemId: any) {

--- a/Angular/src/app/shared/bia-shared/feature-templates/members/views/members-index/members-index.component.html
+++ b/Angular/src/app/shared/bia-shared/feature-templates/members/views/members-index/members-index.component.html
@@ -28,7 +28,7 @@
       <ng-template pTemplate="customControl">
         <div fxLayout="row" fxLayoutGap="20px" class="bia-table-controller-container">
           <i class="pi pi-table bia-pointer" [class]="crudConfiguration.useCalcMode?'enable':'disabled'" 
-          (click)="useClacModeChange(!crudConfiguration.useCalcMode)" 
+          (click)="useCalcModeChange(!crudConfiguration.useCalcMode)" 
           pTooltip="{{ 'bia.useCalcMode' | translate }}" tooltipPosition="top" ></i>
           <i class="pi pi-eye bia-pointer" [class]="crudConfiguration.useView?'enable':'disabled'" 
           (click)="useViewChange(!crudConfiguration.useView)"


### PR DESCRIPTION
When clicking an element in a table, sends all the data row to "ClickRow" and not only the id
When overriding the onClickRow method of the CrudItemsIndexComponent it allows to use other properties than only the item id